### PR TITLE
Add basic testthat tests for mc_mxnusd script

### DIFF
--- a/.github/workflows/update-R.yml
+++ b/.github/workflows/update-R.yml
@@ -46,8 +46,11 @@ jobs:
           ls -R  # List files to check if R scripts exist
           for script in $(find r -type f -name "*.R"); do
             echo "Running $script"
-            Rscript "$script" || echo "⚠️ Warning: $script failed but continuing..."
+          Rscript "$script" || echo "⚠️ Warning: $script failed but continuing..."
           done
+
+      - name: Run tests
+        run: Rscript -e "testthat::test_dir('tests/testthat')"
 
       - name: Commit and push changes
         run: |

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,1 @@
+testthat::test_dir("tests/testthat")

--- a/tests/testthat/test-mc_mxnusd.R
+++ b/tests/testthat/test-mc_mxnusd.R
@@ -1,0 +1,12 @@
+source("r/mc_mxnusd.R")
+
+testthat::test_that("mc_mxnusd outputs CSVs with rows", {
+  testthat::expect_true(file.exists("data/mc_mxnusd_month.csv"))
+  testthat::expect_true(file.exists("data/mc_mxnusd_5y.csv"))
+
+  month <- readr::read_csv("data/mc_mxnusd_month.csv", show_col_types = FALSE)
+  five_years <- readr::read_csv("data/mc_mxnusd_5y.csv", show_col_types = FALSE)
+
+  testthat::expect_gt(nrow(month), 0)
+  testthat::expect_gt(nrow(five_years), 0)
+})


### PR DESCRIPTION
## Summary
- set up minimal testthat infrastructure
- test that running mc_mxnusd.R creates output data with rows
- run the tests in the update workflow

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat')"` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7b77bf7c832e8e0e897eea253dc4