### PR TITLE
Add theme_skope utility and update plotting scripts

### DIFF
--- a/r/gdp/cycles.R
+++ b/r/gdp/cycles.R
@@ -5,8 +5,8 @@ library(showtext)
 library(svglite)
 library(scales)
 
-font_add_google("Rubik", "Rubik")
-showtext_auto()
+source("r/theme_skope.R")
+skope_load_fonts()
 
 # Define your INEGI API key
 inegi.api = Sys.getenv("INEGI_API")
@@ -127,8 +127,7 @@ series %>% filter(indicator_name == x) %>%
        caption = "Fuente: INEGI") +
   scale_x_date(breaks = scales::date_breaks("5 year"), labels = scales::label_date(format = "%Y")) +
   scale_y_continuous(breaks = scales::breaks_width(2)) + 
-  theme_ipsum_rc(grid = "Y", base_family = "Rubik") +
-  theme(legend.position = "bottom")
+  theme_skope()
   # Save the plot
 ggsave(paste0("plots/gdp/cycles/",x,".svg"),  width = 8, height = 6, create.dir = TRUE)
 }

--- a/r/gdp/gdp.R
+++ b/r/gdp/gdp.R
@@ -11,8 +11,8 @@ library(svglite)
 library(scales)
 
 
-font_add_google("Rubik", "Rubik")
-showtext_auto()
+source("r/theme_skope.R")
+skope_load_fonts()
 
 # Define your INEGI API key
 inegi.api = Sys.getenv("INEGI_API")

--- a/r/gdp/gdppc_sexenios.R
+++ b/r/gdp/gdppc_sexenios.R
@@ -10,8 +10,8 @@ library(showtext)
 library(svglite)
 library(scales)
 
-font_add_google("Rubik", "Rubik")
-showtext_auto()
+source("r/theme_skope.R")
+skope_load_fonts()
 
 # Define your INEGI API key
 inegi.api = Sys.getenv("INEGI_API")

--- a/r/gdp/global_gdp.R
+++ b/r/gdp/global_gdp.R
@@ -8,8 +8,8 @@ library(showtext)
 library(svglite)
 
 
-font_add_google("Rubik", "Rubik")
-showtext_auto()
+source("r/theme_skope.R")
+skope_load_fonts()
 
 
 url <- "https://sdmx.oecd.org/public/rest/data/OECD.SDD.NAD,DSD_NAMAIN1@DF_QNA_EXPENDITURE_GROWTH_OECD,/A..IRL+ARG+BRA+CHN+IND+IDN+RUS+SAU+ZAF+AUS+AUT+BEL+CAN+CHE+CHL+COL+CRI+CZE+DEU+DNK+ESP+FIN+EST+FRA+GBR+GRC+HUN+ISL+LTU+ISR+ITA+JPN+KOR+LUX+LVA+MEX+NLD+NOR+NZL+POL+PRT+SVK+SVN+SWE+TUR+USA+OECD+G20+G7+USMCA+OECDE+EA20+EU27_2020...B1GQ......GY.?startPeriod=2020"

--- a/r/inflation/expectedinflation.R
+++ b/r/inflation/expectedinflation.R
@@ -8,8 +8,8 @@ library(hrbrthemes)
 library(showtext)
 library(svglite)
 
-font_add_google("Rubik", "Rubik")
-showtext_auto()
+source("r/theme_skope.R")
+skope_load_fonts()
 
 # Define your INEGI API key
 setToken(Sys.getenv("BANXICO_API"))

--- a/r/inflation/expectedinflation_long.R
+++ b/r/inflation/expectedinflation_long.R
@@ -7,8 +7,8 @@ library(hrbrthemes)
 library(showtext)
 library(svglite)
 
-font_add_google("Rubik", "Rubik")
-showtext_auto()
+source("r/theme_skope.R")
+skope_load_fonts()
 
 # Define your INEGI API key
 setToken(Sys.getenv("BANXICO_API"))

--- a/r/inflation/inflation.R
+++ b/r/inflation/inflation.R
@@ -8,8 +8,8 @@ library(hrbrthemes)
 library(showtext)
 library(svglite)
 
-font_add_google("Roboto Condensed", "Roboto")
-showtext_auto()
+source("r/theme_skope.R")
+skope_load_fonts()
 
 # Define your INEGI API key
 inegi.api = Sys.getenv("INEGI_API")

--- a/r/inflation/inpc.R
+++ b/r/inflation/inpc.R
@@ -10,8 +10,8 @@ library(hrbrthemes)
 library(showtext)
 library(svglite)
 
-font_add_google("Rubik", "Rubik")
-showtext_auto()
+source("r/theme_skope.R")
+skope_load_fonts()
 
 # Define your INEGI API key
 inegi.api = Sys.getenv("INEGI_API")
@@ -77,8 +77,7 @@ ggplot(df, aes(date, values / 100, color = indicator)) +
   scale_y_continuous(labels = scales::label_percent(), breaks = scales::breaks_pretty()) +  # Use scale_y_continuous if scale_y_percent doesn't work
   scale_x_date() +
   scale_color_manual(values = c("#970639", "#043574")) +
-  theme_ipsum_rc(grid = "Y", base_family = "Rubik") +  # Adjusting theme
-  theme(legend.position = "bottom")
+  theme_skope()  # Adjusting theme
 ggsave("plots/inflation/inpc.svg",  width = 8, height = 6, create.dir = TRUE)
 
 # Fetch the data using the specified series IDs (Subyacente)
@@ -147,7 +146,6 @@ ggplot(sub, aes(date, values / 100, color = indicator)) +  # Divide by 100 for t
     caption = paste("Fuente: INEGI. Última actualización", format(Sys.time(), '%d %b, %Y'))
   ) +
   scale_color_manual(values = c("#970639", "#043574", "black")) +
-  theme_ipsum_rc(grid = "Y", base_family = "Rubik") +
-  theme(legend.position = "bottom") 
+  theme_skope()
 ggsave("plots/inflation/inpc_sub.svg",  width = 8, height = 6, create.dir = TRUE)
 

--- a/r/inflation/inpp.R
+++ b/r/inflation/inpp.R
@@ -10,8 +10,8 @@ library(hrbrthemes)
 library(showtext)
 library(svglite)
 
-font_add_google("Rubik", "Rubik")
-showtext_auto()
+source("r/theme_skope.R")
+skope_load_fonts()
 
 # Define your INEGI API key
 inegi.api = Sys.getenv("INEGI_API")
@@ -88,7 +88,6 @@ ggplot(serie, aes(date, pc/100, color = indicator)) +
                             by = "1 year"),
                date_labels = "%Y") +  # Format labels as only the year
   scale_color_manual(values = c("#970639", "#043574", "#015b51")) +
-  theme_ipsum_rc(grid = "Y", base_family = "Rubik") +
-  theme(legend.position="bottom")
+  theme_skope()
 ggsave("plots/inflation/inpp.svg",  width = 8, height = 6, create.dir = TRUE)
 

--- a/r/inflation/weights.R
+++ b/r/inflation/weights.R
@@ -8,8 +8,8 @@ library(tidyverse)
 library(showtext)
 library(svglite)
 
-font_add_google("Rubik", "Rubik")
-showtext_auto()
+source("r/theme_skope.R")
+skope_load_fonts()
 
 # Define your INEGI API key
 inegi.api = Sys.getenv("INEGI_API")

--- a/r/labor/labor-employment.R
+++ b/r/labor/labor-employment.R
@@ -10,8 +10,8 @@ library(svglite)
 library(scales)
 library(zoo)
 
-font_add_google("Rubik", "Rubik")
-showtext_auto()
+source("r/theme_skope.R")
+skope_load_fonts()
 
 # Define your INEGI API key
 inegi.api = Sys.getenv("INEGI_API")
@@ -48,8 +48,7 @@ ggplot(df, aes(as.Date(paste(year, "01-01", sep = "-"), format = "%Y-%m-%d"), va
   scale_color_manual(values = c("#970639", "#043574", "#015b51")) +
   scale_y_continuous(breaks = scales::breaks_pretty(), labels = scales::label_percent(), limits = c(2/100, 6/100)) + 
   scale_x_date(labels = scales::date_format("%Y"), breaks = scales::date_breaks("2 years")) + 
-  theme_ipsum_rc(grid = "Y", base_family = "Rubik") +
-  theme(legend.position = "bottom") 
+  theme_skope()
 ggsave("plots/labor/labor-unemployment.svg",  width = 8, height = 6, create.dir = TRUE)
 
 
@@ -75,6 +74,5 @@ ggplot(gap, aes(as.Date(paste(year, "01-01", sep = "-"), format = "%Y-%m-%d"), g
   ) +
   scale_y_continuous(breaks = scales::breaks_pretty(n = 8), limits = c(0.8, 1.2)) +
   scale_x_date(breaks = scales::date_breaks("2 years"), labels = scales::date_format("%Y")) +
-  theme_ipsum_rc(grid = "Y", base_family = "Rubik") +
-  theme(legend.position = "bottom") 
+  theme_skope()
 ggsave("plots/labor/labor-gap-unemployment.svg",  width = 8, height = 6, create.dir = TRUE)

--- a/r/labor/labor-gap.R
+++ b/r/labor/labor-gap.R
@@ -10,8 +10,8 @@ library(svglite)
 library(scales)
 library(zoo)
 
-font_add_google("Rubik", "Rubik")
-showtext_auto()
+source("r/theme_skope.R")
+skope_load_fonts()
 
 # Define your INEGI API key
 inegi.api = Sys.getenv("INEGI_API")
@@ -48,8 +48,7 @@ ggplot(df, aes(as.Date(paste(year, "01-01", sep = "-"), format = "%Y-%m-%d"), va
   scale_color_manual(values = c("#970639", "#043574", "#015b51")) +
   scale_x_date(breaks = scales::date_breaks("2 years"), labels = scales::label_date("%Y")) +
   scale_y_percent(breaks = scales::breaks_pretty(8) , limits = c(0.3, 0.85)) + 
-  theme_ipsum_rc(grid = "Y", base_family = "Rubik") +
-  theme(legend.position = "bottom") 
+  theme_skope()
 ggsave("plots/labor/labor-share.svg",  width = 8, height = 6, create.dir = TRUE)
 
 
@@ -74,6 +73,5 @@ ggplot(gap, aes(as.Date(paste(year, "01-01", sep = "-"), format = "%Y-%m-%d"), g
   ) +
   scale_y_continuous(breaks = scales::breaks_pretty(), limits = c(1.6, 2)) + 
   scale_x_date(breaks = scales::date_breaks("2 years"), labels = scales::label_date("%Y")) +
-  theme_ipsum_rc(grid = "Y", base_family = "Rubik") +
-  theme(legend.position = "bottom") 
+  theme_skope()
 ggsave("plots/labor/labor-gap.svg",  width = 8, height = 6, create.dir = TRUE)

--- a/r/labor/labor-informality.R
+++ b/r/labor/labor-informality.R
@@ -10,8 +10,8 @@ library(svglite)
 library(scales)
 library(zoo)
 
-font_add_google("Rubik", "Rubik")
-showtext_auto()
+source("r/theme_skope.R")
+skope_load_fonts()
 
 # Define your INEGI API key
 inegi.api = Sys.getenv("INEGI_API")
@@ -49,8 +49,7 @@ ggplot(df, aes(as.Date(paste(year, "01-01", sep = "-"), format = "%Y-%m-%d"), va
   scale_color_manual(values = c("#970639", "#043574", "#015b51", "black")) +
   scale_y_continuous(breaks = scales::breaks_pretty(), labels = scales::label_percent(), limits = c(25/100, 31/100)) +
   scale_x_date(labels = scales::date_format("%Y"), breaks = scales::date_breaks("2 years")) + 
-  theme_ipsum_rc(grid = "Y", base_family = "Rubik") +
-  theme(legend.position = "bottom") 
+  theme_skope()
 ggsave("plots/labor/labor-tosi.svg",  width = 8, height = 6, create.dir = TRUE)
 
 
@@ -76,6 +75,5 @@ ggplot(gap, aes(as.Date(paste(year, "01-01", sep = "-"), format = "%Y-%m-%d"), g
   ) +
   scale_y_continuous(breaks = scales::breaks_pretty(6), limits = c(0.88, 1)) +
   scale_x_date(breaks = scales::date_breaks("2 years"), labels = scales::date_format("%Y")) +
-  theme_ipsum_rc(grid = "Y", base_family = "Rubik") +
-  theme(legend.position = "bottom") 
+  theme_skope()
 ggsave("plots/labor/labor-gap-tosi.svg",  width = 8, height = 6, create.dir = TRUE)

--- a/r/labor/labor-neet.R
+++ b/r/labor/labor-neet.R
@@ -10,8 +10,8 @@ library(svglite)
 library(scales)
 library(zoo)
 
-font_add_google("Rubik", "Rubik")
-showtext_auto()
+source("r/theme_skope.R")
+skope_load_fonts()
 
 # Define your INEGI API key
 inegi.api = Sys.getenv("INEGI_API")
@@ -52,8 +52,7 @@ ggplot(df, aes(as.Date(paste(year, "01-01", sep = "-"), format = "%Y-%m-%d"), va
   scale_color_manual(values = c("#970639", "#043574", "#015b51", "black")) +
   scale_y_continuous(breaks = scales::breaks_pretty(), labels = scales::label_percent(), limits = c(25/100, 31/100)) +
   scale_x_date(labels = scales::date_format("%Y"), breaks = scales::date_breaks("2 years")) + 
-  theme_ipsum_rc(grid = "Y", base_family = "Rubik") +
-  theme(legend.position = "bottom") 
+  theme_skope()
 ggsave("plots/labor/labor-tosi.svg",  width = 8, height = 6, create.dir = TRUE)
 
 
@@ -79,6 +78,5 @@ ggplot(gap, aes(as.Date(paste(year, "01-01", sep = "-"), format = "%Y-%m-%d"), g
   ) +
   scale_y_continuous(breaks = scales::breaks_pretty(6), limits = c(0.88, 1)) +
   scale_x_date(breaks = scales::date_breaks("2 years"), labels = scales::date_format("%Y")) +
-  theme_ipsum_rc(grid = "Y", base_family = "Rubik") +
-  theme(legend.position = "bottom") 
+  theme_skope()
 ggsave("plots/labor/labor-gap-tosi.svg",  width = 8, height = 6, create.dir = TRUE)

--- a/r/theme_skope.R
+++ b/r/theme_skope.R
@@ -1,0 +1,13 @@
+library(hrbrthemes)
+library(showtext)
+library(ggplot2)
+
+skope_load_fonts <- function() {
+  font_add_google("Rubik", "Rubik")
+  showtext_auto()
+}
+
+theme_skope <- function(grid = "Y") {
+  theme_ipsum_rc(grid = grid, base_family = "Rubik") +
+    theme(legend.position = "bottom")
+}


### PR DESCRIPTION
## Summary
- provide `theme_skope()` and `skope_load_fonts()` utilities
- source `theme_skope.R` and call `skope_load_fonts()` at the start of plotting scripts
- replace repeated theme code with `theme_skope()`

## Testing
- `Rscript tests/testthat.R` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7c658754832e82b6fb20c2d7cae5