### PR TITLE
Improve plots with unified captions

### DIFF
--- a/r/gdp/cycles.R
+++ b/r/gdp/cycles.R
@@ -58,7 +58,8 @@ series_filt %>%
   ggplot(aes(date, values, col = indicator_name)) +
     # Líneas sólidas y dotdash según antigüedad
     geom_line(linewidth = 1) +
-    geom_hline(yintercept = 100, col = "black", linewidth = 0.5) + 
+    geom_hline(yintercept = 100, col = "black", linewidth = 0.5) +
+    highlight_last(series_filt, "date", "values", label_fmt = label_number(accuracy = 0.1)) +
 
     # Etiquetas y títulos
     labs(
@@ -66,7 +67,7 @@ series_filt %>%
       subtitle = "Componente cíclico",
       x        = NULL,
       y        = "Por abajo de 100 indica recesión",
-      caption  = "Fuente: INEGI",
+      caption  = skope_caption("INEGI", max(series_filt$date)),
       colour   = NULL            # quita el título de la leyenda
     ) +
 
@@ -102,7 +103,7 @@ series_filt %>%
     ) +
 
     # Tema
-    theme_ipsum_rc(grid = "Y", base_family = "Rubik") +
+    theme_skope() +
     theme(
       legend.position = "bottom",
       legend.margin   = margin(t = 5), 
@@ -119,14 +120,15 @@ series %>% filter(indicator_name == x) %>%
   ggplot(aes(date, values, col = indicator_name)) +
   geom_line(data = ~ filter(.x, date <= Sys.Date() - years(2)), col = "#970639", linewidth = 1) +
   geom_line(data = ~ filter(.x, date > Sys.Date() - years(2)), col = "#970639", linetype = "dotdash", linewidth = 1) +
-  geom_hline(yintercept = 100, col = "black", linewidth = 0.5) + 
+  geom_hline(yintercept = 100, col = "black", linewidth = 0.5) +
+  highlight_last(filter(series, indicator_name == x), "date", "values", label_fmt = label_number(accuracy = 0.1)) +
   labs(title = x,
        subtitle = "Componente cíclico",
        y = "",
        x = "",
-       caption = "Fuente: INEGI") +
+       caption = skope_caption("INEGI", max(series$date))) +
   scale_x_date(breaks = scales::date_breaks("5 year"), labels = scales::label_date(format = "%Y")) +
-  scale_y_continuous(breaks = scales::breaks_width(2)) + 
+  scale_y_continuous(breaks = scales::breaks_width(2)) +
   theme_skope()
   # Save the plot
 ggsave(paste0("plots/gdp/cycles/",x,".svg"),  width = 8, height = 6, create.dir = TRUE)

--- a/r/inflation/expectedinflation_long.R
+++ b/r/inflation/expectedinflation_long.R
@@ -26,30 +26,34 @@ series.df <- reduce(list(first, med, third), full_join, by = "date") %>%
   filter(date >= Sys.Date() - years(2))
 colnames(series.df)[2:4] <- c("Primer cuartil", "Mediana", "Tercer cuartil")
 
-series.long <- series.df %>% 
+series.long <- series.df %>%
   pivot_longer(
     !date,
     names_to = "index",
     values_to = "value"
-  ) %>% 
+  ) %>%
   mutate(index = factor(index, levels = c("Primer cuartil", "Mediana", "Tercer cuartil")))
+
+last_points <- series.long %>% group_by(index) %>% filter(date == max(date))
 
 
 ggplot(series.long, aes(date, value/100, color = index, group = date)) +
   geom_line(color = "grey", linewidth = 1) +
-  geom_point(size = 3) +
+  geom_point(data = last_points, size = 3) +
+  geom_text(data = last_points, aes(label = scales::percent(value/100, accuracy = 0.1)),
+            vjust = -0.5, hjust = 0, show.legend = FALSE, size = 3) +
   labs(
     title = paste("Expectativas de inflación", year(Sys.Date())),
     subtitle = "Encuestas Sobre las Expectativas de los Especialistas en Economía del \nSector Privado Expectativas de Largo Plazo de la Inflación para los Próximos 5 a 8 Años",
     x = "",
     y = "",
     color = "",
-    caption = paste("Fuente: Banxico. Última actualización", format(Sys.time(), '%d %b, %Y'))
+    caption = skope_caption("Banxico", max(series.long$date))
   ) +
   scale_y_percent(labels = scales::percent_format(accuracy = 0.1), limits = c(0.034, 0.039)) +  # Two decimal places
   scale_x_date(labels = scales::date_format("%b\n%Y")) +
-  scale_color_manual(values=c("#009076", "#ffe59c", "#c71e1d")) + 
-  theme_ipsum_rc(base_family = "Rubik") +
+  scale_color_manual(values=c("#009076", "#ffe59c", "#c71e1d")) +
+  theme_skope() +
   theme(
     legend.position = "bottom"
   )

--- a/r/labor/labor-employment.R
+++ b/r/labor/labor-employment.R
@@ -34,20 +34,24 @@ df <- series %>%
   reframe(values = mean(values, na.rm = TRUE))  
 
 
+last_points <- df %>% filter(year == max(year))
+
 ggplot(df, aes(as.Date(paste(year, "01-01", sep = "-"), format = "%Y-%m-%d"), values/100, color = meta_indicatorid)) +
   geom_line(size = 1) +
-  geom_point(size = 2, aes(col = meta_indicatorid)) + 
+  geom_point(data = last_points, size = 2, aes(col = meta_indicatorid)) +
+  geom_text(data = last_points, aes(label = scales::percent(values/100, accuracy = 0.1)),
+            vjust = -0.5, hjust = 0, show.legend = FALSE, size = 3) +
   labs(
     title = "Tasa de desempleo (UR)",
     subtitle = "Personas desempleadas (15 años y más) como % de la fuerza laboral",
     y = "",
     x = paste("Último dato:", format(max(df$year))),
     color = "",
-    caption = paste("Fuente: INEGI. Última actualización", format(Sys.time(), '%d %b, %Y'))
+    caption = skope_caption("INEGI", as.Date(paste(max(df$year), "01-01", sep = "-")))
   ) +
   scale_color_manual(values = c("#970639", "#043574", "#015b51")) +
-  scale_y_continuous(breaks = scales::breaks_pretty(), labels = scales::label_percent(), limits = c(2/100, 6/100)) + 
-  scale_x_date(labels = scales::date_format("%Y"), breaks = scales::date_breaks("2 years")) + 
+  scale_y_continuous(breaks = scales::breaks_pretty(), labels = scales::label_percent(), limits = c(2/100, 6/100)) +
+  scale_x_date(labels = scales::date_format("%Y"), breaks = scales::date_breaks("2 years")) +
   theme_skope()
 ggsave("plots/labor/labor-unemployment.svg",  width = 8, height = 6, create.dir = TRUE)
 
@@ -60,9 +64,12 @@ gap <- df %>%
   select(year, gap) %>% 
   ungroup()
 
+last_gap <- gap %>% filter(year == max(year))
+
 ggplot(gap, aes(as.Date(paste(year, "01-01", sep = "-"), format = "%Y-%m-%d"), gap)) +
   geom_line(size = 1, col = "#970639") +
-  geom_point(size = 2, col = "#970639") + 
+  geom_point(data = last_gap, size = 2, col = "#970639") +
+  geom_text(data = last_gap, aes(label = round(gap, 2)), vjust = -0.5, hjust = 0, show.legend = FALSE, size = 3, col = "#970639") +
   # geom_text(aes(label = round(gap,2)), nudge_y = 0.02) +
   labs(
     title = "Brecha UR Mujeres y Hombres",
@@ -70,7 +77,7 @@ ggplot(gap, aes(as.Date(paste(year, "01-01", sep = "-"), format = "%Y-%m-%d"), g
     y = "",
     x = paste("Último dato:", format(max(df$year))),
     color = "",
-    caption = paste("Fuente: INEGI. Última actualización", format(Sys.time(), '%d %b, %Y'))
+    caption = skope_caption("INEGI", as.Date(paste(max(df$year), "01-01", sep = "-")))
   ) +
   scale_y_continuous(breaks = scales::breaks_pretty(n = 8), limits = c(0.8, 1.2)) +
   scale_x_date(breaks = scales::date_breaks("2 years"), labels = scales::date_format("%Y")) +

--- a/r/labor/labor-gap.R
+++ b/r/labor/labor-gap.R
@@ -34,16 +34,19 @@ df <- series %>%
   reframe(values = mean(values, na.rm = TRUE), .groups = "drop")  
 
 
+last_df <- df %>% filter(year == max(year))
+
 ggplot(df, aes(as.Date(paste(year, "01-01", sep = "-"), format = "%Y-%m-%d"), values/100, color = meta_indicatorid)) +
   geom_line(size = 1) +
-  geom_point(size = 2) +
+  geom_point(data = last_df, size = 2) +
+  geom_text(data = last_df, aes(label = scales::percent(values/100, accuracy = 0.1)), vjust = -0.5, hjust = 0, show.legend = FALSE, size = 3) +
   labs(
     title = "Relación empleo-población (EPR)",
     subtitle = "Personas empleadas como % de la población en edad laboral (15 años y más)",
     y = "",
     x = paste("Último dato:", format(max(df$year))),
     color = "",
-    caption = paste("Fuente: INEGI. Última actualización", format(Sys.time(), '%d %b, %Y'))
+    caption = skope_caption("INEGI", as.Date(paste(max(df$year), "01-01", sep = "-")))
   ) +
   scale_color_manual(values = c("#970639", "#043574", "#015b51")) +
   scale_x_date(breaks = scales::date_breaks("2 years"), labels = scales::label_date("%Y")) +
@@ -60,16 +63,19 @@ gap <- df %>%
   select(year, gap) %>% 
   ungroup()
 
+last_gap <- gap %>% filter(year == max(year))
+
 ggplot(gap, aes(as.Date(paste(year, "01-01", sep = "-"), format = "%Y-%m-%d"), gap)) +
   geom_line(size = 1, col = "#970639") +
-  geom_point(size = 2, col = "#970639") + 
+  geom_point(data = last_gap, size = 2, col = "#970639") +
+  geom_text(data = last_gap, aes(label = round(gap, 2)), vjust = -0.5, hjust = 0, show.legend = FALSE, col = "#970639", size = 3) +
   labs(
     title = "Brecha EPR Mujeres y Hombres",
     subtitle = "EPR hombres/EPR mujeres",
     y = "",
     x = paste("Último dato:", format(max(df$year))),
     color = "",
-    caption = paste("Fuente: INEGI. Última actualización", format(Sys.time(), '%d %b, %Y'))
+    caption = skope_caption("INEGI", as.Date(paste(max(df$year), "01-01", sep = "-")))
   ) +
   scale_y_continuous(breaks = scales::breaks_pretty(), limits = c(1.6, 2)) + 
   scale_x_date(breaks = scales::date_breaks("2 years"), labels = scales::label_date("%Y")) +

--- a/r/theme_skope.R
+++ b/r/theme_skope.R
@@ -1,6 +1,8 @@
 library(hrbrthemes)
 library(showtext)
 library(ggplot2)
+library(dplyr)
+library(scales)
 
 skope_load_fonts <- function() {
   font_add_google("Rubik", "Rubik")
@@ -10,4 +12,47 @@ skope_load_fonts <- function() {
 theme_skope <- function(grid = "Y") {
   theme_ipsum_rc(grid = grid, base_family = "Rubik") +
     theme(legend.position = "bottom")
+}
+
+#' Create a standard caption with source and update information
+#'
+#' @param source Character string with the data source
+#' @param last_date Date of the most recent observation
+#' @return Character caption
+skope_caption <- function(source, last_date) {
+  paste0(
+    "Fuente: ", source,
+    ". Datos hasta ", format(last_date, "%d %b, %Y"),
+    "\nÚltima actualización: ", format(Sys.time(), "%d %b, %Y")
+  )
+}
+
+#' Highlight the last observation on a time series plot
+#'
+#' @param data Data frame used in the plot
+#' @param x Name of the x variable as string
+#' @param y Name of the y variable as string
+#' @param color Point and text color
+#' @param label_fmt Label format function from scales
+#' @return List of ggplot2 layers
+highlight_last <- function(data, x, y, color = "#970639",
+                           label_fmt = label_number(accuracy = 0.1)) {
+  last <- data %>% filter(.data[[x]] == max(.data[[x]], na.rm = TRUE))
+  list(
+    geom_point(data = last, aes(.data[[x]], .data[[y]]),
+               color = color, size = 2),
+    geom_text(
+      data = last,
+      aes(
+        .data[[x]],
+        .data[[y]],
+        label = label_fmt(.data[[y]])
+      ),
+      color = color,
+      vjust = -0.5,
+      hjust = 0,
+      size = 3,
+      show.legend = FALSE
+    )
+  )
 }


### PR DESCRIPTION
## Summary
- add `skope_caption` and `highlight_last` helpers
- use helpers across GDP, inflation, and labor scripts
- emphasize last observations and show data currency in captions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f86188500832ea97845bc7a1f5c3d